### PR TITLE
feature: print runtime git commit

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -11,10 +11,12 @@ RUN export GOCACHE=/tmp && \
     export GOARCH=${ARCH} && \
     export CGO_ENABLED=0 && \
     export GOOS=linux && \
-	go build -o dist/images/rama -ldflags "-w -s" -v ./cmd/cni && \
-	go build -o dist/images/rama-daemon -ldflags "-w -s" -v ./cmd/daemon && \
-    go build -o dist/images/rama-manager -v ./cmd/manager && \
-    go build -o dist/images/rama-webhook -v ./cmd/webhook
+    export COMMIT_ID=`git rev-parse --short HEAD 2>/dev/null` && \
+    go build -o dist/images/rama -ldflags "-w -s" -v ./cmd/cni && \
+    go build -ldflags "-w -s -X \"main.gitCommit=`echo $COMMIT_ID`\" " -o dist/images/rama-daemon -v ./cmd/daemon && \
+    go build -ldflags "-X \"main.gitCommit=`git rev-parse --short HEAD 2>/dev/null`\" " -o dist/images/rama-manager -v ./cmd/manager && \
+    go build -o dist/images/rama-webhook -v ./cmd/webhook && \
+    echo $COMMIT_ID > ./COMMIT_ID
 
 RUN cd /go/src/github.com/oecp/rama/dist/secrets && \
     sh generate-tls-certificates.sh
@@ -50,6 +52,7 @@ COPY --from=builder /go/src/github.com/oecp/rama/dist/images/rama /rama/rama
 COPY --from=builder /go/src/github.com/oecp/rama/dist/images/rama-daemon /rama/rama-daemon
 COPY --from=builder /go/src/github.com/oecp/rama/dist/images/rama-manager /rama/rama-manager
 COPY --from=builder /go/src/github.com/oecp/rama/dist/images/rama-webhook /rama/rama-webhook
+COPY --from=builder /go/src/github.com/oecp/rama/COMMIT_ID /rama/COMMIT_ID
 
 RUN mkdir -p /tmp/k8s-webhook-server/serving-certs
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -11,10 +11,12 @@ RUN export GOCACHE=/tmp && \
     export GOARCH=${ARCH} && \
     export CGO_ENABLED=0 && \
     export GOOS=linux && \
-	go build -o dist/images/rama -ldflags "-w -s" -v ./cmd/cni && \
-	go build -o dist/images/rama-daemon -ldflags "-w -s" -v ./cmd/daemon && \
-    go build -o dist/images/rama-manager -v ./cmd/manager && \
-    go build -o dist/images/rama-webhook -v ./cmd/webhook
+    export COMMIT_ID=`git rev-parse --short HEAD 2>/dev/null` && \
+    go build -o dist/images/rama -ldflags "-w -s" -v ./cmd/cni && \
+    go build -ldflags "-w -s -X \"main.gitCommit=`echo $COMMIT_ID`\" " -o dist/images/rama-daemon -v ./cmd/daemon && \
+    go build -ldflags "-X \"main.gitCommit=`git rev-parse --short HEAD 2>/dev/null`\" " -o dist/images/rama-manager -v ./cmd/manager && \
+    go build -o dist/images/rama-webhook -v ./cmd/webhook && \
+    echo $COMMIT_ID > ./COMMIT_ID
 
 RUN cd /go/src/github.com/oecp/rama/dist/secrets && \
     sh generate-tls-certificates.sh
@@ -50,6 +52,7 @@ COPY --from=builder /go/src/github.com/oecp/rama/dist/images/rama /rama/rama
 COPY --from=builder /go/src/github.com/oecp/rama/dist/images/rama-daemon /rama/rama-daemon
 COPY --from=builder /go/src/github.com/oecp/rama/dist/images/rama-manager /rama/rama-manager
 COPY --from=builder /go/src/github.com/oecp/rama/dist/images/rama-webhook /rama/rama-webhook
+COPY --from=builder /go/src/github.com/oecp/rama/COMMIT_ID /rama/COMMIT_ID
 
 RUN mkdir -p /tmp/k8s-webhook-server/serving-certs
 

--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -30,9 +30,13 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
+var gitCommit string
+
 func main() {
 	klog.InitFlags(nil)
 	defer klog.Flush()
+
+	klog.Infof("Starting rama daemon with git commit: %v", gitCommit)
 
 	config, err := daemonconfig.ParseFlags()
 	if err != nil {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -28,6 +28,8 @@ import (
 	"github.com/oecp/rama/pkg/manager"
 )
 
+var gitCommit string
+
 func init() {
 	klog.InitFlags(nil)
 }
@@ -36,6 +38,7 @@ func main() {
 	// parse flags
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
+	klog.Infof("Starting rama manager with git commit: %v", gitCommit)
 	klog.Infof("known features: %v", feature.KnownFeatures())
 
 	var (


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/oecp/rama/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Print runtime commit id of Rama in rama-manager and rama-daemon logs. It helps us to find the correct commit id while debugging. 

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
Link a flag "main.gitVersion" while building binaries, and add logs in rama-daemon and rama-manager.

### Describe how to verify it
Run rama-daemon and rama-manager pod, logs of "starting rama manager with git version: <commit id>" will be printed at the first place. Executing command of "cat /rama/COMMIT_ID" in pod will show commit id too.

### Special notes for reviews