### PR TITLE
improvement: set ipv4/ipv6 neigh gc thresh

### DIFF
--- a/pkg/daemon/config/config.go
+++ b/pkg/daemon/config/config.go
@@ -46,6 +46,10 @@ const (
 	DefaultIptablesCheckDuration  = 5 * time.Second
 	DefaultVxlanBaseReachableTime = 5 * time.Second
 
+	DefaultNeighGCThresh1 = 1024
+	DefaultNeighGCThresh2 = 2048
+	DefaultNeighGCThresh3 = 4096
+
 	DefaultLocalDirectTableNum     = 39999
 	DefaultToOverlaySubnetTableNum = 40000
 	DefaultOverlayMarkTableNum     = 40001
@@ -81,6 +85,10 @@ type Configuration struct {
 
 	KubeClient kubernetes.Interface
 	RamaClient clientset.Interface
+
+	NeighGCThresh1 int
+	NeighGCThresh2 int
+	NeighGCThresh3 int
 }
 
 // ParseFlags will parse cmd args then init kubeClient and configuration
@@ -99,6 +107,9 @@ func ParseFlags() (*Configuration, error) {
 		argVlanCheckTimeout        = pflag.Duration("vlan-check-timeout", DefaultVlanCheckTimeout, "The timeout of vlan network environment check while pod creating")
 		argVxlanUDPPort            = pflag.Int("vxlan-udp-port", DefaultVxlanUDPPort, "The local udp port which vxlan tunnel use")
 		argVxlanBaseReachableTime  = pflag.Duration("vxlan-base-reachable-time", DefaultVxlanBaseReachableTime, "The time for neigh caches of vxlan device to get STALE from REACHABLE")
+		argNeighGCThresh1          = pflag.Int("neigh-gc-thresh1", DefaultNeighGCThresh1, "value to set net.ipv4/ipv6.neigh.default.gc_thresh1")
+		argNeighGCThresh2          = pflag.Int("neigh-gc-thresh2", DefaultNeighGCThresh2, "value to set net.ipv4/ipv6.neigh.default.gc_thresh2")
+		argNeighGCThresh3          = pflag.Int("neigh-gc-thresh3", DefaultNeighGCThresh3, "value to set net.ipv4/ipv6.neigh.default.gc_thresh3")
 	)
 
 	// mute info log for ipset lib
@@ -141,6 +152,9 @@ func ParseFlags() (*Configuration, error) {
 		VxlanUDPPort:            *argVxlanUDPPort,
 		IptablesCheckDuration:   *argIptableCheckDuration,
 		VxlanBaseReachableTime:  *argVxlanBaseReachableTime,
+		NeighGCThresh1:          *argNeighGCThresh1,
+		NeighGCThresh2:          *argNeighGCThresh2,
+		NeighGCThresh3:          *argNeighGCThresh3,
 	}
 
 	if *argPreferVlanInterfaces == "" {

--- a/pkg/daemon/containernetwork/constants.go
+++ b/pkg/daemon/containernetwork/constants.go
@@ -33,6 +33,14 @@ const (
 
 	RpFilterSysctl = "/proc/sys/net/ipv4/conf/%s/rp_filter"
 
+	IPv4NeighGCThresh1 = "/proc/sys/net/ipv4/neigh/default/gc_thresh1"
+	IPv4NeighGCThresh2 = "/proc/sys/net/ipv4/neigh/default/gc_thresh2"
+	IPv4NeighGCThresh3 = "/proc/sys/net/ipv4/neigh/default/gc_thresh3"
+
+	IPv6NeighGCThresh1 = "/proc/sys/net/ipv6/neigh/default/gc_thresh1"
+	IPv6NeighGCThresh2 = "/proc/sys/net/ipv6/neigh/default/gc_thresh2"
+	IPv6NeighGCThresh3 = "/proc/sys/net/ipv6/neigh/default/gc_thresh3"
+
 	ProxyNdpSysctl       = "/proc/sys/net/ipv6/conf/%s/proxy_ndp"
 	IPv6ForwardingSysctl = "/proc/sys/net/ipv6/conf/%s/forwarding"
 

--- a/pkg/daemon/server/container.go
+++ b/pkg/daemon/server/container.go
@@ -61,7 +61,8 @@ func (cdh cniDaemonHandler) configureNic(podName, podNamespace, netns, container
 
 	klog.Infof("Configure container nic for %v.%v", podName, podNamespace)
 	if err = containernetwork.ConfigureContainerNic(containerNicName, hostNicName, nodeIfName,
-		allocatedIPs, macAddr, vlanID, podNS, mtu, cdh.config.VlanCheckTimeout, networkType); err != nil {
+		allocatedIPs, macAddr, vlanID, podNS, mtu, cdh.config.VlanCheckTimeout, networkType,
+		cdh.config.NeighGCThresh1, cdh.config.NeighGCThresh2, cdh.config.NeighGCThresh3); err != nil {
 		return "", fmt.Errorf("failed to configure container nic for %v.%v: %v", podName, podNamespace, err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/oecp/rama/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
A large scale Rama cluster may bring a large number of neigh table entries on each node, which might cause network not working well occasionally.

To fix this, we need to provide a method to set neigh/default/gc_thresh kernel parameters on each node.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
Ensure neigh/default/gc_thresh kernel parameters while creating pod. 

### Describe how to verify it
Deploy a cluster with new rama image.

### Special notes for reviews