### PR TITLE
Nil interfaceToIPSliceMap when CreateNeighManager

### DIFF
--- a/pkg/daemon/neigh/neigh.go
+++ b/pkg/daemon/neigh/neigh.go
@@ -39,7 +39,7 @@ type Manager struct {
 func CreateNeighManager(family int) *Manager {
 	return &Manager{
 		family:                family,
-		interfaceToIPSliceMap: nil,
+		interfaceToIPSliceMap: make(map[string]IPMap),
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/oecp/rama/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
bug fix. 
### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
None
### Describe how to verify it
no need
### Special notes for reviews
* Why this bug didn't happen before?
  * Because every time when calling `AddPodInfo` which would cause panic because of the bug,  `ResetInfos` will be called.