### PR TITLE
improvement: node local vxlan ip can be choosed

### DIFF
--- a/pkg/constants/annotations.go
+++ b/pkg/constants/annotations.go
@@ -28,7 +28,7 @@ const (
 
 	AnnotationNetworkType = "networking.alibaba.com/network-type"
 
-	AnnotationNodeVtepIP  = "networking.alibaba.com/vtep-ip"
-	AnnotationNodeVtepMac = "networking.alibaba.com/vtep-mac"
-	AnnotationNodeIPList  = "networking.alibaba.com/ip-list"
+	AnnotationNodeVtepIP           = "networking.alibaba.com/vtep-ip"
+	AnnotationNodeVtepMac          = "networking.alibaba.com/vtep-mac"
+	AnnotationNodeLocalVxlanIPList = "networking.alibaba.com/local-vxlan-ip-list"
 )

--- a/pkg/daemon/config/config.go
+++ b/pkg/daemon/config/config.go
@@ -19,7 +19,9 @@ package config
 import (
 	"flag"
 	"fmt"
+	"net"
 	"os"
+	"strings"
 	"time"
 
 	clientset "github.com/oecp/rama/pkg/client/clientset/versioned"
@@ -60,8 +62,9 @@ type Configuration struct {
 	VlanMTU  int
 	VxlanMTU int
 
-	NodeVlanIfName  string
-	NodeVxlanIfName string
+	NodeVlanIfName             string
+	NodeVxlanIfName            string
+	ExtraNodeLocalVxlanIPCidrs []*net.IPNet
 
 	BindPort     int
 	VxlanUDPPort int
@@ -86,19 +89,20 @@ type Configuration struct {
 // ParseFlags will parse cmd args then init kubeClient and configuration
 func ParseFlags() (*Configuration, error) {
 	var (
-		argPreferInterfaces        = pflag.String("prefer-interfaces", "", "[deprecated]The preferred vlan interfaces used to inter-host pod communication, default: the default route interface")
-		argPreferVlanInterfaces    = pflag.String("prefer-vlan-interfaces", "", "The preferred vlan interfaces used to inter-host pod communication, default: the default route interface")
-		argPreferVxlanInterfaces   = pflag.String("prefer-vxlan-interfaces", "", "The preferred vxlan interfaces used to inter-host pod communication, default: the default route interface")
-		argBindSocket              = pflag.String("bind-socket", "/var/run/rama.sock", "The socket daemon bind to.")
-		argKubeConfigFile          = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
-		argBindPort                = pflag.Int("healthy-server-port", DefaultBindPort, "The port which daemon server bind")
-		argLocalDirectTableNum     = pflag.Int("local-direct-table", DefaultLocalDirectTableNum, "The number of local direct routing table")
-		argIptableCheckDuration    = pflag.Duration("iptables-check-duration", DefaultIptablesCheckDuration, "The time period for iptables manager to check iptables rules")
-		argToOverlaySubnetTableNum = pflag.Int("to-overlay-table", DefaultToOverlaySubnetTableNum, "The number of to overlay subnet routing table")
-		argOverlayMarkTableNum     = pflag.Int("overlay-mark-table", DefaultOverlayMarkTableNum, "The number of overlay mark routing table")
-		argVlanCheckTimeout        = pflag.Duration("vlan-check-timeout", DefaultVlanCheckTimeout, "The timeout of vlan network environment check while pod creating")
-		argVxlanUDPPort            = pflag.Int("vxlan-udp-port", DefaultVxlanUDPPort, "The local udp port which vxlan tunnel use")
-		argVxlanBaseReachableTime  = pflag.Duration("vxlan-base-reachable-time", DefaultVxlanBaseReachableTime, "The time for neigh caches of vxlan device to get STALE from REACHABLE")
+		argPreferInterfaces           = pflag.String("prefer-interfaces", "", "[deprecated]The preferred vlan interfaces used to inter-host pod communication, default: the default route interface")
+		argPreferVlanInterfaces       = pflag.String("prefer-vlan-interfaces", "", "The preferred vlan interfaces used to inter-host pod communication, default: the default route interface")
+		argPreferVxlanInterfaces      = pflag.String("prefer-vxlan-interfaces", "", "The preferred vxlan interfaces used to inter-host pod communication, default: the default route interface")
+		argBindSocket                 = pflag.String("bind-socket", "/var/run/rama.sock", "The socket daemon bind to.")
+		argKubeConfigFile             = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
+		argBindPort                   = pflag.Int("healthy-server-port", DefaultBindPort, "The port which daemon server bind")
+		argLocalDirectTableNum        = pflag.Int("local-direct-table", DefaultLocalDirectTableNum, "The number of local direct routing table")
+		argIptableCheckDuration       = pflag.Duration("iptables-check-duration", DefaultIptablesCheckDuration, "The time period for iptables manager to check iptables rules")
+		argToOverlaySubnetTableNum    = pflag.Int("to-overlay-table", DefaultToOverlaySubnetTableNum, "The number of to overlay subnet routing table")
+		argOverlayMarkTableNum        = pflag.Int("overlay-mark-table", DefaultOverlayMarkTableNum, "The number of overlay mark routing table")
+		argVlanCheckTimeout           = pflag.Duration("vlan-check-timeout", DefaultVlanCheckTimeout, "The timeout of vlan network environment check while pod creating")
+		argVxlanUDPPort               = pflag.Int("vxlan-udp-port", DefaultVxlanUDPPort, "The local udp port which vxlan tunnel use")
+		argVxlanBaseReachableTime     = pflag.Duration("vxlan-base-reachable-time", DefaultVxlanBaseReachableTime, "The time for neigh caches of vxlan device to get STALE from REACHABLE")
+		argExtraNodeLocalVxlanIPCidrs = pflag.String("extra-node-local-vxlan-ip-cidrs", "", "Cidrs to select node extra local vxlan ip, e.g., \"192.168.10.0/24,10.2.3.0/24\"")
 	)
 
 	// mute info log for ipset lib
@@ -145,6 +149,15 @@ func ParseFlags() (*Configuration, error) {
 
 	if *argPreferVlanInterfaces == "" {
 		config.NodeVlanIfName = *argPreferInterfaces
+	}
+
+	if *argExtraNodeLocalVxlanIPCidrs != "" {
+		var err error
+		config.ExtraNodeLocalVxlanIPCidrs, err = parseCidrString(*argExtraNodeLocalVxlanIPCidrs)
+		if err != nil {
+			klog.Errorf("parse extra node local vxlan ip cidrs failed: %v", err)
+			return nil, fmt.Errorf("parse extra node local vxlan ip cidrs failed: %v", err)
+		}
 	}
 
 	if err := config.initNicConfig(); err != nil {
@@ -235,4 +248,19 @@ func (config *Configuration) initKubeClient() error {
 	}
 
 	return nil
+}
+
+func parseCidrString(cidrListString string) ([]*net.IPNet, error) {
+	var cidrList []*net.IPNet
+	cidrStringList := strings.Split(cidrListString, ",")
+	for _, cidrString := range cidrStringList {
+		_, cidr, err := net.ParseCIDR(cidrString)
+		if err != nil {
+			return nil, fmt.Errorf("parse cidr %v failed: %v", cidrString, err)
+		}
+
+		cidrList = append(cidrList, cidr)
+	}
+
+	return cidrList, nil
 }

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -438,13 +438,13 @@ func (c *Controller) iptablesSyncLoop() {
 
 				if node.Annotations[constants.AnnotationNodeVtepMac] == "" ||
 					node.Annotations[constants.AnnotationNodeVtepIP] == "" ||
-					node.Annotations[constants.AnnotationNodeIPList] == "" {
+					node.Annotations[constants.AnnotationNodeLocalVxlanIPList] == "" {
 					klog.Infof("node %v's vtep information has not been updated", node.Name)
 					continue
 				}
 
-				ipStringList := strings.Split(node.Annotations[constants.AnnotationNodeIPList], ",")
-				for _, ipString := range ipStringList {
+				nodeLocalVxlanipStringList := strings.Split(node.Annotations[constants.AnnotationNodeLocalVxlanIPList], ",")
+				for _, ipString := range nodeLocalVxlanipStringList {
 					ip := net.ParseIP(ipString)
 					if ip.To4() != nil {
 						// v4 address


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/oecp/rama/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
If node in a cluster has multiple ip addresses, or one of the ip address is the same for every node, rama overlay may work incorrectly.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Only use vtep ip and address of node object as node local vxlan ip by default. Other ip addresses of node can be choose by "--extra-node-local-vxlan-ip-cidrs" parameter of rama-daemon.

### Describe how to verify it
Update rama-daemon in a exist cluster.

### Special notes for reviews