### PR TITLE
improvement: arp request source enhance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' && github.event.action != 'unassigned' }}
 
       - name: Build and push amd64
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.5.0
         with:
           context: .
           file: ./Dockerfile.amd64
@@ -78,7 +78,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push arm64
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.5.0
         with:
           context: .
           file: ./Dockerfile.arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' && github.event.action != 'unassigned' }}
 
       - name: Build and push amd64
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.5.0
         with:
           context: .
           file: ./Dockerfile.amd64
@@ -60,7 +60,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Build and push arm64
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.5.0
         with:
           context: .
           file: ./Dockerfile.arm64

--- a/pkg/daemon/addr/addr.go
+++ b/pkg/daemon/addr/addr.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2021 The Rama Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addr
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	ramav1 "github.com/oecp/rama/pkg/apis/networking/v1"
+	"github.com/oecp/rama/pkg/daemon/containernetwork"
+
+	"github.com/oecp/rama/pkg/constants"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+type subnetToPodMap map[string]net.IP
+
+type Manager struct {
+	family        int
+	localNodeName string
+
+	// one valid local pod to one subnet and one local vlan interface name
+	interfaceToSubnetMap map[string]subnetToPodMap
+}
+
+func CreateAddrManager(family int, nodeName string) *Manager {
+	return &Manager{
+		family:               family,
+		localNodeName:        nodeName,
+		interfaceToSubnetMap: map[string]subnetToPodMap{},
+	}
+}
+
+func (m *Manager) ResetInfos() {
+	m.interfaceToSubnetMap = map[string]subnetToPodMap{}
+}
+
+func (m *Manager) TryAddPodInfo(forwardNodeIfName string, subnet *net.IPNet, podIP net.IP) {
+	if subnetMap := m.interfaceToSubnetMap[forwardNodeIfName]; subnetMap == nil {
+		m.interfaceToSubnetMap[forwardNodeIfName] = subnetToPodMap{}
+	}
+
+	// we only need one local pod ip for every subnet
+	if _, exist := m.interfaceToSubnetMap[forwardNodeIfName][subnet.String()]; !exist {
+		m.interfaceToSubnetMap[forwardNodeIfName][subnet.String()] = podIP
+	}
+}
+
+// For some environments, physical router or switcher might check the sender address
+// of arp request, if the sender ip address is not in the same subnet of target address
+// the arp request will be take as invalid and dropped.
+//
+// So we will always keep an valid local pod address in the vlan interface without local routes.
+func (m *Manager) SyncAddresses(getIPInstanceByAddress func(net.IP) (*ramav1.IPInstance, error)) error {
+	// clear all invalid enhanced addresses
+	linkList, err := netlink.LinkList()
+	if err != nil {
+		return fmt.Errorf("list link failed: %v", err)
+	}
+
+	existEnhancedAddrMap := map[string]map[string]netlink.Addr{}
+
+	for _, link := range linkList {
+		// ignore container network virtual interfaces
+		if strings.HasSuffix(link.Attrs().Name, containernetwork.ContainerHostLinkSuffix) ||
+			strings.HasSuffix(link.Attrs().Name, containernetwork.ContainerInitLinkSuffix) ||
+			strings.HasPrefix(link.Attrs().Name, "veth") {
+
+			continue
+		}
+
+		addrList, err := netlink.AddrList(link, m.family)
+		if err != nil {
+			return fmt.Errorf("list addresses for link %v failed: %v", link.Attrs().Name, err)
+		}
+
+		for _, addr := range addrList {
+			isEnhancedAddr, err := checkIfEnhancedAddr(link, addr, m.family)
+			if err != nil {
+				return fmt.Errorf("check addr %v enhanced address failed: %v", addr.String(), err)
+			}
+
+			if isEnhancedAddr {
+				linkName := link.Attrs().Name
+
+				if existEnhancedAddrMap[linkName] == nil {
+					existEnhancedAddrMap[linkName] = map[string]netlink.Addr{}
+				}
+
+				cidr := net.IPNet{
+					IP:   addr.IP.Mask(addr.Mask),
+					Mask: addr.Mask,
+				}
+
+				existEnhancedAddrMap[linkName][cidr.String()] = addr
+			}
+		}
+	}
+
+	// clear enhanced addresses which are impossible to be used
+	for existLinkName, existSubnetMap := range existEnhancedAddrMap {
+		existLink, err := netlink.LinkByName(existLinkName)
+		if err != nil {
+			return fmt.Errorf("find exist link %v failed: %v", existLinkName, err)
+		}
+
+		if targetSubnetMap, exist := m.interfaceToSubnetMap[existLinkName]; !exist {
+			// link doesn't need enhanced address any more
+			for _, enhancedAddr := range existSubnetMap {
+				if err := netlink.AddrDel(existLink, &enhancedAddr); err != nil {
+					return fmt.Errorf("delete link enhanced addr %v failed: %v", enhancedAddr.String(), err)
+				}
+			}
+		} else {
+			// subnet doesn't need enhanced address any more
+			for subnetString, enhancedAddr := range existSubnetMap {
+				if _, exist := targetSubnetMap[subnetString]; !exist {
+					if err := netlink.AddrDel(existLink, &enhancedAddr); err != nil {
+						return fmt.Errorf("delete link subnet enhanced addr %v failed: %v", enhancedAddr.String(), err)
+					}
+				}
+			}
+		}
+	}
+
+	// ensure all needed enhanced addresses
+	for forwardNodeIfName, targetSubnetMap := range m.interfaceToSubnetMap {
+		forwardNodeIf, err := netlink.LinkByName(forwardNodeIfName)
+		if err != nil {
+			return fmt.Errorf("find interface %v failed: %v", forwardNodeIfName, err)
+		}
+
+		for subnetString, podIP := range targetSubnetMap {
+			var outOfDateEnhancedAddr *netlink.Addr
+			_, subnetCidr, err := net.ParseCIDR(subnetString)
+			if err != nil {
+				return fmt.Errorf("parse subnet cidr %v failed: %v", subnetString, err)
+			}
+
+			// subnet enhanced address exists
+			if _, exist := existEnhancedAddrMap[forwardNodeIfName]; exist {
+				if _, exist := existEnhancedAddrMap[forwardNodeIfName][subnetString]; exist {
+					// if forward node if has exist enhanced address which is in the same subnet with target pod ip
+					if enhancedAddr, exist := existEnhancedAddrMap[forwardNodeIfName][subnetString]; exist {
+						// enhanced address attempt to add is the same as origin
+						if enhancedAddr.IP.Equal(podIP) {
+							continue
+						}
+
+						// check if exist enhanced address is valid
+						ipInstance, err := getIPInstanceByAddress(enhancedAddr.IP)
+						if err != nil {
+							return fmt.Errorf("get ip instance by address %v failed: %v", enhancedAddr.IP.String(), err)
+						}
+
+						if ipInstance != nil {
+							nodeName := ipInstance.Labels[constants.LabelNode]
+							if nodeName == m.localNodeName {
+								// exist enhanced address is still valid, just keep it
+								continue
+							}
+						}
+
+						// ip instance not found or is no longer in this node, need to be refreshed
+						outOfDateEnhancedAddr = &enhancedAddr
+					}
+				}
+			}
+
+			if err := ensureSubnetEnhancedAddr(forwardNodeIf, &netlink.Addr{
+				IPNet: &net.IPNet{
+					IP:   podIP,
+					Mask: subnetCidr.Mask,
+				},
+				Label: "",
+				Flags: unix.IFA_F_NOPREFIXROUTE,
+			}, outOfDateEnhancedAddr, m.family); err != nil {
+				return fmt.Errorf("ensure subnet enhanced addr %v failed: %v", podIP.String(), err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/daemon/addr/utils.go
+++ b/pkg/daemon/addr/utils.go
@@ -1,0 +1,87 @@
+package addr
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+func checkIfEnhancedAddr(link netlink.Link, addr netlink.Addr, family int) (bool, error) {
+	routeList, err := netlink.RouteListFiltered(family, &netlink.Route{
+		Table:     unix.RT_TABLE_LOCAL,
+		LinkIndex: link.Attrs().Index,
+		Src:       addr.IP,
+	}, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_OIF|netlink.RT_FILTER_SRC)
+
+	if err != nil {
+		return false, fmt.Errorf("list local routes for interface %v and src %v failed: %v",
+			link.Attrs().Name, addr.IP.String(), err)
+	}
+
+	if len(routeList) == 0 && addr.Flags&unix.IFA_F_SECONDARY == 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func ensureSubnetEnhancedAddr(link netlink.Link, newEnhancedAddr, outOfDateEnhancedAddr *netlink.Addr, family int) error {
+	if newEnhancedAddr == nil {
+		return fmt.Errorf("new enhanced address should not be nil")
+	}
+
+	if outOfDateEnhancedAddr != nil {
+		cidr1 := net.IPNet{
+			IP:   outOfDateEnhancedAddr.IP.Mask(outOfDateEnhancedAddr.Mask),
+			Mask: outOfDateEnhancedAddr.Mask,
+		}
+
+		cidr2 := net.IPNet{
+			IP:   newEnhancedAddr.IP.Mask(newEnhancedAddr.Mask),
+			Mask: newEnhancedAddr.Mask,
+		}
+
+		if cidr1.String() != cidr2.String() {
+			return fmt.Errorf("out-of-date enhanced address %v need to be in the same subnet "+
+				"with in new enhanced address %v", outOfDateEnhancedAddr, newEnhancedAddr)
+		}
+	}
+
+	if err := netlink.AddrAdd(link, newEnhancedAddr); err != nil {
+		return fmt.Errorf("add enhanced addr %v for interface %v failed: %v",
+			newEnhancedAddr.IP.String(), link.Attrs().Name, err)
+	}
+
+	if outOfDateEnhancedAddr != nil {
+		if err := netlink.AddrDel(link, outOfDateEnhancedAddr); err != nil {
+			return fmt.Errorf("del out-of-date enhanced addr %v for interface %v failed: %v",
+				outOfDateEnhancedAddr.IP.String(), link.Attrs().Name, err)
+		}
+	}
+
+	// Seems like if an new address is assigned to a interface while an old address in the same subnet exists,
+	// the new address will become a "secondary" address which has no local routes. Add once the old address
+	// is deleted, the new address will get to a normal address and kernel will apply three new local routes for it.
+	//
+	// So local routes should be delete after the old out-of-date address is deleted.
+	routeList, err := netlink.RouteListFiltered(family, &netlink.Route{
+		Table:     unix.RT_TABLE_LOCAL,
+		LinkIndex: link.Attrs().Index,
+		Src:       newEnhancedAddr.IP,
+	}, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_OIF|netlink.RT_FILTER_SRC)
+
+	if err != nil {
+		return fmt.Errorf("list local routes for interface %v and src %v failed: %v",
+			link.Attrs().Name, newEnhancedAddr.IP.String(), err)
+	}
+
+	for _, route := range routeList {
+		if err := netlink.RouteDel(&route); err != nil {
+			return fmt.Errorf("delete local route %v failed: %v", route.String(), err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/daemon/addr/utils.go
+++ b/pkg/daemon/addr/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Rama Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package addr
 
 import (
@@ -20,7 +36,7 @@ func checkIfEnhancedAddr(link netlink.Link, addr netlink.Addr, family int) (bool
 			link.Attrs().Name, addr.IP.String(), err)
 	}
 
-	if len(routeList) == 0 && addr.Flags&unix.IFA_F_SECONDARY == 0 {
+	if len(routeList) == 0 && addr.Flags&unix.IFA_F_SECONDARY == 0 && addr.Flags&unix.IFA_F_NOPREFIXROUTE != 0 {
 		return true, nil
 	}
 

--- a/pkg/daemon/config/config.go
+++ b/pkg/daemon/config/config.go
@@ -110,9 +110,9 @@ func ParseFlags() (*Configuration, error) {
 		argVlanCheckTimeout           = pflag.Duration("vlan-check-timeout", DefaultVlanCheckTimeout, "The timeout of vlan network environment check while pod creating")
 		argVxlanUDPPort               = pflag.Int("vxlan-udp-port", DefaultVxlanUDPPort, "The local udp port which vxlan tunnel use")
 		argVxlanBaseReachableTime     = pflag.Duration("vxlan-base-reachable-time", DefaultVxlanBaseReachableTime, "The time for neigh caches of vxlan device to get STALE from REACHABLE")
-		argNeighGCThresh1             = pflag.Int("neigh-gc-thresh1", DefaultNeighGCThresh1, "value to set net.ipv4/ipv6.neigh.default.gc_thresh1")
-		argNeighGCThresh2             = pflag.Int("neigh-gc-thresh2", DefaultNeighGCThresh2, "value to set net.ipv4/ipv6.neigh.default.gc_thresh2")
-		argNeighGCThresh3             = pflag.Int("neigh-gc-thresh3", DefaultNeighGCThresh3, "value to set net.ipv4/ipv6.neigh.default.gc_thresh3")
+		argNeighGCThresh1             = pflag.Int("neigh-gc-thresh1", DefaultNeighGCThresh1, "Value to set net.ipv4/ipv6.neigh.default.gc_thresh1")
+		argNeighGCThresh2             = pflag.Int("neigh-gc-thresh2", DefaultNeighGCThresh2, "Value to set net.ipv4/ipv6.neigh.default.gc_thresh2")
+		argNeighGCThresh3             = pflag.Int("neigh-gc-thresh3", DefaultNeighGCThresh3, "Value to set net.ipv4/ipv6.neigh.default.gc_thresh3")
 		argExtraNodeLocalVxlanIPCidrs = pflag.String("extra-node-local-vxlan-ip-cidrs", "", "Cidrs to select node extra local vxlan ip, e.g., \"192.168.10.0/24,10.2.3.0/24\"")
 	)
 

--- a/pkg/daemon/controller/utils.go
+++ b/pkg/daemon/controller/utils.go
@@ -17,6 +17,9 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
+	"net"
+
 	ramav1 "github.com/oecp/rama/pkg/apis/networking/v1"
 	"github.com/oecp/rama/pkg/daemon/iptables"
 	"github.com/oecp/rama/pkg/daemon/neigh"
@@ -42,4 +45,37 @@ func (c *Controller) getIPtablesManager(ipVersion ramav1.IPVersion) *iptables.Ma
 		return c.iptablesV6Manager
 	}
 	return c.iptablesV4Manager
+}
+
+func (c *Controller) getIPInstanceByAddress(address net.IP) (*ramav1.IPInstance, error) {
+	ipInstanceList, err := c.ipInstanceIndexer.ByIndex(ByInstanceIPIndexer, address.String())
+	if err != nil {
+		return nil, fmt.Errorf("get ip instance by ip %v indexer failed: %v", address.String(), err)
+	}
+
+	if len(ipInstanceList) > 1 {
+		return nil, fmt.Errorf("get more than one ip instance for ip %v", address.String())
+	}
+
+	if len(ipInstanceList) == 1 {
+		instance, ok := ipInstanceList[0].(*ramav1.IPInstance)
+		if !ok {
+			return nil, fmt.Errorf("transform obj to ipinstance failed")
+		}
+
+		return instance, nil
+	}
+
+	if len(ipInstanceList) == 0 {
+		// not found
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf("ip instance for address %v not found", address.String())
+}
+
+func initErrorMessageWrapper(prefix string) func(string, ...interface{}) string {
+	return func(format string, args ...interface{}) string {
+		return prefix + fmt.Sprintf(format, args...)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/oecp/rama/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
For rama underlay network, the packets of pods will get through host network without tunnel encapsulation. And for our implementation, node is actually the next-hop gateway for pod, which needs to do arp resolving for pod network.

If a node doesn't have an ip address in pod subnet, it will use the ip of the node itself as arp packet's sender ip while resolving pod gateway's address, which might cause problem if the host network will check the sender's ip and regards the arp packet invalid if the sender ip is not in the same subnet with target ip.

This pr will add maintain a local pod address on node vlan forward interface for every rama underlay subnet, the local pod address will be took as arp sender address by kernel.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it
Maintain a local pod address on node vlan forward interface for every rama underlay subnet, change these addresses while ip instance is changed.

### Describe how to verify it
Need an environment with arp sender ip check.

### Special notes for reviews