### PR TITLE
improvement: remove duplicated overlay subnet route entries when autoNatOutgoing is true

### DIFF
--- a/pkg/daemon/route/route.go
+++ b/pkg/daemon/route/route.go
@@ -224,7 +224,7 @@ func (m *Manager) SyncRoutes() error {
 		}
 	}
 
-	var allValidSubnet []*net.IPNet
+	var allValidUnderlaySubnet []*net.IPNet
 	for _, info := range m.subnetInfoMap {
 		if info.isOverlay {
 			if _, exist := existOverlaySubnetRouteMap[info.cidr.String()]; !exist {
@@ -243,9 +243,9 @@ func (m *Manager) SyncRoutes() error {
 					return fmt.Errorf("add to overlay pod subnet route for %v failed: %v", info.cidr.String(), err)
 				}
 			}
+		} else {
+			allValidUnderlaySubnet = append(allValidUnderlaySubnet, info.cidr)
 		}
-
-		allValidSubnet = append(allValidSubnet, info.cidr)
 	}
 
 	// Ensure overlay mark table rule if overlay interface exist.
@@ -295,7 +295,7 @@ func (m *Manager) SyncRoutes() error {
 	for _, info := range m.subnetInfoMap {
 		// Append from pod subnet rules which don't exist and adapter subnet configuration
 		if err := ensureFromPodSubnetRuleAndRoutes(info.forwardNodeIfName, info.cidr,
-			info.gateway, info.autoNatOutgoing, info.isOverlay, m.family, allValidSubnet); err != nil {
+			info.gateway, info.autoNatOutgoing, info.isOverlay, m.family, allValidUnderlaySubnet); err != nil {
 			return fmt.Errorf("add subnet %v rule and routes failed: %v", info, err)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/oecp/rama/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it

remove duplicated overlay subnet route entries

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

When overlay subnet route entries is added to toOverlaySubnet route table, DO NOT append it to allValidSubnet again.

### Describe how to verify it

check by `ip rule` and `ip route show table XXXX`

### Special notes for reviews