### PR TITLE
bugfix: add routes for excluded ips

### DIFF
--- a/pkg/daemon/controller/subnet.go
+++ b/pkg/daemon/controller/subnet.go
@@ -18,12 +18,9 @@ package controller
 
 import (
 	"fmt"
-	"net"
 
 	ramav1 "github.com/oecp/rama/pkg/apis/networking/v1"
 	"github.com/oecp/rama/pkg/daemon/containernetwork"
-
-	"github.com/vishvananda/netlink"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog"
@@ -124,14 +121,11 @@ func (c *Controller) reconcileSubnet() error {
 			netID = network.Spec.NetID
 		}
 
-		subnetCidr, err := netlink.ParseIPNet(subnet.Spec.Range.CIDR)
-		if err != nil {
-			return fmt.Errorf("failed to parse subnet cidr %v error: %v", subnet.Spec.Range.CIDR, err)
-		}
+		subnetCidr, gatewayIP, startIP, endIP, excludeIPs,
+			reservedIPs, err := parseSubnetSpecRangeMeta(&subnet.Spec.Range)
 
-		gatewayIP := net.ParseIP(subnet.Spec.Range.Gateway)
-		if gatewayIP == nil {
-			return fmt.Errorf("invalid gateway ip %v", subnet.Spec.Range.Gateway)
+		if err != nil {
+			return fmt.Errorf("parse subnet %v spec range meta failed: %v", subnet.Name, err)
 		}
 
 		var forwardNodeIfName string
@@ -154,7 +148,8 @@ func (c *Controller) reconcileSubnet() error {
 
 		// create policy route
 		routeManager := c.getRouterManager(subnet.Spec.Range.Version)
-		routeManager.AddSubnetInfo(subnetCidr, gatewayIP, forwardNodeIfName, autoNatOutgoing, isOverlay)
+		routeManager.AddSubnetInfo(subnetCidr, gatewayIP, startIP, endIP, excludeIPs, reservedIPs,
+			forwardNodeIfName, autoNatOutgoing, isOverlay)
 	}
 
 	if err := c.routeV4Manager.SyncRoutes(); err != nil {

--- a/pkg/daemon/controller/subnet.go
+++ b/pkg/daemon/controller/subnet.go
@@ -122,7 +122,7 @@ func (c *Controller) reconcileSubnet() error {
 		}
 
 		subnetCidr, gatewayIP, startIP, endIP, excludeIPs,
-			reservedIPs, err := parseSubnetSpecRangeMeta(&subnet.Spec.Range)
+			_, err := parseSubnetSpecRangeMeta(&subnet.Spec.Range)
 
 		if err != nil {
 			return fmt.Errorf("parse subnet %v spec range meta failed: %v", subnet.Name, err)
@@ -148,7 +148,7 @@ func (c *Controller) reconcileSubnet() error {
 
 		// create policy route
 		routeManager := c.getRouterManager(subnet.Spec.Range.Version)
-		routeManager.AddSubnetInfo(subnetCidr, gatewayIP, startIP, endIP, excludeIPs, reservedIPs,
+		routeManager.AddSubnetInfo(subnetCidr, gatewayIP, startIP, endIP, excludeIPs,
 			forwardNodeIfName, autoNatOutgoing, isOverlay)
 	}
 

--- a/pkg/daemon/route/route.go
+++ b/pkg/daemon/route/route.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net"
 
+	daemonutils "github.com/oecp/rama/pkg/daemon/utils"
+
 	"github.com/oecp/rama/pkg/daemon/iptables"
 
 	"github.com/vishvananda/netlink"
@@ -49,16 +51,6 @@ import (
 // Local pod direct table doesn't need to be maintained manually,
 // because route will be deleted by kernel while specific device is not exist.
 
-type SubnetInfo struct {
-	cidr              *net.IPNet
-	gateway           net.IP
-	forwardNodeIfName string
-	autoNatOutgoing   bool
-	isOverlay         bool
-}
-
-type SubnetInfoMap map[string]*SubnetInfo
-
 type Manager struct {
 	// Use fixed table num to mark "local pod direct rule"
 	localDirectTableNum int
@@ -74,7 +66,9 @@ type Manager struct {
 
 	family int
 
-	subnetInfoMap SubnetInfoMap
+	overlaySubnetInfoMap  SubnetInfoMap
+	underlaySubnetInfoMap SubnetInfoMap
+	totalSubnetInfoMap    SubnetInfoMap
 }
 
 func CreateRouteManager(localDirectTableNum, toOverlaySubnetTableNum, overlayMarkTableNum, family int) (*Manager, error) {
@@ -119,17 +113,19 @@ func CreateRouteManager(localDirectTableNum, toOverlaySubnetTableNum, overlayMar
 		}
 
 		for _, route := range routes {
-			if route.LinkIndex <= 0 {
-				return nil, fmt.Errorf("find no device route, to overlay subnet route table %v is used by others", localDirectTableNum)
+			if route.LinkIndex <= 0 && !isExcludeRoute(&route) {
+				return nil, fmt.Errorf("find no device route, to overlay subnet route table %v is used by others", toOverlaySubnetTableNum)
 			}
 
-			overlayIf, err := netlink.LinkByIndex(route.LinkIndex)
-			if err != nil {
-				return nil, fmt.Errorf("find overlay interface by index %v failed: %v", route.LinkIndex, err)
-			}
+			if route.LinkIndex > 0 {
+				overlayIf, err := netlink.LinkByIndex(route.LinkIndex)
+				if err != nil {
+					return nil, fmt.Errorf("find overlay interface by index %v failed: %v", route.LinkIndex, err)
+				}
 
-			if route.Gw != nil || overlayIf.Type() != "vxlan" {
-				return nil, fmt.Errorf("to overlay subnet route table %v is used by others", toOverlaySubnetTableNum)
+				if route.Gw != nil || overlayIf.Type() != "vxlan" {
+					return nil, fmt.Errorf("to overlay subnet route table %v is used by others", toOverlaySubnetTableNum)
+				}
 			}
 		}
 	}
@@ -165,31 +161,65 @@ func CreateRouteManager(localDirectTableNum, toOverlaySubnetTableNum, overlayMar
 		toOverlaySubnetTableNum: toOverlaySubnetTableNum,
 		overlayMarkTableNum:     overlayMarkTableNum,
 		family:                  family,
-		subnetInfoMap:           SubnetInfoMap{},
+		totalSubnetInfoMap:      SubnetInfoMap{},
+		overlaySubnetInfoMap:    SubnetInfoMap{},
+		underlaySubnetInfoMap:   SubnetInfoMap{},
 	}, nil
 }
 
 func (m *Manager) ResetInfos() {
-	m.subnetInfoMap = SubnetInfoMap{}
+	m.totalSubnetInfoMap = SubnetInfoMap{}
+	m.underlaySubnetInfoMap = SubnetInfoMap{}
+	m.overlaySubnetInfoMap = SubnetInfoMap{}
 }
 
-func (m *Manager) AddSubnetInfo(cidr *net.IPNet, gateway net.IP, forwardNodeIfName string, autoNatOutgoing, isOverlay bool) {
-	m.subnetInfoMap[cidr.String()] = &SubnetInfo{
-		cidr:              cidr,
-		forwardNodeIfName: forwardNodeIfName,
-		isOverlay:         isOverlay,
-		gateway:           gateway,
-		autoNatOutgoing:   autoNatOutgoing,
+func (m *Manager) AddSubnetInfo(cidr *net.IPNet, gateway, start, end net.IP, excludeIPs, reservedIPs []net.IP,
+	forwardNodeIfName string, autoNatOutgoing, isOverlay bool) {
+
+	cidrString := cidr.String()
+	if _, exist := m.totalSubnetInfoMap[cidrString]; !exist {
+		m.totalSubnetInfoMap[cidrString] = &SubnetInfo{
+			cidr:              cidr,
+			forwardNodeIfName: forwardNodeIfName,
+			gateway:           gateway,
+			autoNatOutgoing:   autoNatOutgoing,
+			includedIPRanges:  []*daemonutils.IPRange{},
+			excludeIPs:        []net.IP{},
+			reservedIPs:       []net.IP{},
+		}
+	}
+
+	subnetInfo := m.totalSubnetInfoMap[cidrString]
+
+	if len(reservedIPs) != 0 {
+		subnetInfo.reservedIPs = append(subnetInfo.reservedIPs, reservedIPs...)
+	}
+
+	if len(excludeIPs) != 0 {
+		subnetInfo.excludeIPs = append(subnetInfo.excludeIPs, excludeIPs...)
+	}
+
+	if start != nil || end != nil {
+		if start == nil {
+			start = cidr.IP
+		}
+
+		if end == nil {
+			end = daemonutils.LastIP(cidr)
+		}
+
+		if ipRange, _ := daemonutils.CreateIPRange(start, end); ipRange != nil {
+			subnetInfo.includedIPRanges = append(subnetInfo.includedIPRanges, ipRange)
+		}
 	}
 
 	if isOverlay {
 		// overlay interface should always be the same one
 		m.overlayIfName = forwardNodeIfName
+		m.overlaySubnetInfoMap[cidrString] = subnetInfo
+	} else {
+		m.underlaySubnetInfoMap[cidrString] = subnetInfo
 	}
-}
-
-func (m *Manager) GetSubnetInfo() SubnetInfoMap {
-	return m.subnetInfoMap
 }
 
 func (m *Manager) SyncRoutes() error {
@@ -207,62 +237,25 @@ func (m *Manager) SyncRoutes() error {
 		return fmt.Errorf("append overlay mark route rule failed: %v", err)
 	}
 
-	// Sync to overlay pod subnet routes
-	toOverlaySubnetRoutes, err := listRoutesByTable(m.toOverlaySubnetTableNum, m.family)
+	// Find excluded ip ranges.
+	underlayExcludeIPBlockMap, err := findExcludeIPBlockMap(m.underlaySubnetInfoMap)
 	if err != nil {
-		return fmt.Errorf("list to overlay pod subnet routes for table %v failed: %v", m.toOverlaySubnetTableNum, err)
+		return fmt.Errorf("find exclude ip blocks for underlay subnet failed: %v", err)
 	}
 
-	existOverlaySubnetRouteMap := map[string]bool{}
-	for _, route := range toOverlaySubnetRoutes {
-		if info, exist := m.subnetInfoMap[route.Dst.String()]; !exist {
-			if err := netlink.RouteDel(&route); err != nil {
-				return fmt.Errorf("delete route %v failed: %v", route.String(), err)
-			}
-		} else if info.isOverlay {
-			existOverlaySubnetRouteMap[route.Dst.String()] = true
-		}
+	overlayExcludeIPBlockMap, err := findExcludeIPBlockMap(m.overlaySubnetInfoMap)
+	if err != nil {
+		return fmt.Errorf("find exclude ip blocks for overlay subnet failed: %v", err)
 	}
 
-	var allValidUnderlaySubnet []*net.IPNet
-	for _, info := range m.subnetInfoMap {
-		if info.isOverlay {
-			if _, exist := existOverlaySubnetRouteMap[info.cidr.String()]; !exist {
-
-				overlayLink, err := netlink.LinkByName(info.forwardNodeIfName)
-				if err != nil {
-					return fmt.Errorf("get overlay link %v failed: %v", info.forwardNodeIfName, err)
-				}
-
-				if err := netlink.RouteReplace(&netlink.Route{
-					Dst:       info.cidr,
-					LinkIndex: overlayLink.Attrs().Index,
-					Table:     m.toOverlaySubnetTableNum,
-					Scope:     netlink.SCOPE_UNIVERSE,
-				}); err != nil {
-					return fmt.Errorf("add to overlay pod subnet route for %v failed: %v", info.cidr.String(), err)
-				}
-			}
-		} else {
-			allValidUnderlaySubnet = append(allValidUnderlaySubnet, info.cidr)
-		}
+	// Sync to overlay pod subnet routes
+	if err := m.ensureToOverlaySubnetRoutes(overlayExcludeIPBlockMap); err != nil {
+		return fmt.Errorf("ensure to overlay pod subnet routes failed: %v", err)
 	}
 
 	// Ensure overlay mark table rule if overlay interface exist.
-	if m.overlayIfName != "" {
-		overlayLink, err := netlink.LinkByName(m.overlayIfName)
-		if err != nil {
-			return fmt.Errorf("get overlay link %v failed: %v", m.overlayIfName, err)
-		}
-
-		if err := netlink.RouteReplace(&netlink.Route{
-			Dst:       defaultRouteDstByFamily(m.family),
-			LinkIndex: overlayLink.Attrs().Index,
-			Table:     m.overlayMarkTableNum,
-			Scope:     netlink.SCOPE_UNIVERSE,
-		}); err != nil {
-			return fmt.Errorf("add overlay mark route failed: %v", err)
-		}
+	if err := m.ensureOverlayMarkRoutes(); err != nil {
+		return fmt.Errorf("ensure overlay mark routes failed: %v", err)
 	}
 
 	ruleList, err := netlink.RuleList(m.family)
@@ -279,7 +272,7 @@ func (m *Manager) SyncRoutes() error {
 
 		if isFromPodSubnetRule {
 			// Delete subnet rules which are not supposed to exist.
-			if _, exist := m.subnetInfoMap[rule.Src.String()]; !exist {
+			if _, exist := m.totalSubnetInfoMap[rule.Src.String()]; !exist {
 				rule.Family = m.family
 				if err := netlink.RuleDel(&rule); err != nil {
 					return fmt.Errorf("del subnet policy rule error: %v", err)
@@ -292,11 +285,89 @@ func (m *Manager) SyncRoutes() error {
 		}
 	}
 
-	for _, info := range m.subnetInfoMap {
-		// Append from pod subnet rules which don't exist and adapter subnet configuration
+	for _, info := range m.overlaySubnetInfoMap {
+		// Append overlay from pod subnet rules which don't exist and adapter subnet configuration
 		if err := ensureFromPodSubnetRuleAndRoutes(info.forwardNodeIfName, info.cidr,
-			info.gateway, info.autoNatOutgoing, info.isOverlay, m.family, allValidUnderlaySubnet); err != nil {
+			info.gateway, info.autoNatOutgoing, true, m.family,
+			m.underlaySubnetInfoMap, underlayExcludeIPBlockMap); err != nil {
 			return fmt.Errorf("add subnet %v rule and routes failed: %v", info, err)
+		}
+	}
+
+	for _, info := range m.underlaySubnetInfoMap {
+		// Append underlay from pod subnet rules which don't exist and adapter subnet configuration
+		if err := ensureFromPodSubnetRuleAndRoutes(info.forwardNodeIfName, info.cidr,
+			info.gateway, info.autoNatOutgoing, false, m.family,
+			nil, nil); err != nil {
+			return fmt.Errorf("add subnet %v rule and routes failed: %v", info, err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) ensureToOverlaySubnetRoutes(excludeIPBlockMap map[string]*net.IPNet) error {
+	// Sync to overlay pod subnet routes
+	toOverlaySubnetRoutes, err := listRoutesByTable(m.toOverlaySubnetTableNum, m.family)
+	if err != nil {
+		return fmt.Errorf("list to overlay pod subnet routes for table %v failed: %v", m.toOverlaySubnetTableNum, err)
+	}
+
+	existOverlaySubnetRouteMap := map[string]bool{}
+	for _, route := range toOverlaySubnetRoutes {
+		// skip exclude routes
+		if isExcludeRoute(&route) {
+			continue
+		}
+
+		if _, exist := m.overlaySubnetInfoMap[route.Dst.String()]; !exist {
+			if err := netlink.RouteDel(&route); err != nil {
+				return fmt.Errorf("delete route %v failed: %v", route.String(), err)
+			}
+		} else {
+			existOverlaySubnetRouteMap[route.Dst.String()] = true
+		}
+	}
+
+	for _, info := range m.overlaySubnetInfoMap {
+		if _, exist := existOverlaySubnetRouteMap[info.cidr.String()]; !exist {
+			overlayLink, err := netlink.LinkByName(info.forwardNodeIfName)
+			if err != nil {
+				return fmt.Errorf("get overlay link %v failed: %v", info.forwardNodeIfName, err)
+			}
+
+			if err := netlink.RouteReplace(&netlink.Route{
+				Dst:       info.cidr,
+				LinkIndex: overlayLink.Attrs().Index,
+				Table:     m.toOverlaySubnetTableNum,
+				Scope:     netlink.SCOPE_UNIVERSE,
+			}); err != nil {
+				return fmt.Errorf("add to overlay pod subnet route for %v failed: %v", info.cidr.String(), err)
+			}
+		}
+	}
+
+	// For the traffic of accessing overlay excluded ip addresses, should not be forced to pass through vxlan device.
+	if err := ensureExcludedIPBlockRoutes(excludeIPBlockMap, m.toOverlaySubnetTableNum, m.family); err != nil {
+		return fmt.Errorf("ensure exclude ip block routes failed: %v", err)
+	}
+	return nil
+}
+
+func (m *Manager) ensureOverlayMarkRoutes() error {
+	if m.overlayIfName != "" {
+		overlayLink, err := netlink.LinkByName(m.overlayIfName)
+		if err != nil {
+			return fmt.Errorf("get overlay link %v failed: %v", m.overlayIfName, err)
+		}
+
+		if err := netlink.RouteReplace(&netlink.Route{
+			Dst:       defaultRouteDstByFamily(m.family),
+			LinkIndex: overlayLink.Attrs().Index,
+			Table:     m.overlayMarkTableNum,
+			Scope:     netlink.SCOPE_UNIVERSE,
+		}); err != nil {
+			return fmt.Errorf("add overlay mark route failed: %v", err)
 		}
 	}
 

--- a/pkg/daemon/route/route.go
+++ b/pkg/daemon/route/route.go
@@ -173,7 +173,7 @@ func (m *Manager) ResetInfos() {
 	m.overlaySubnetInfoMap = SubnetInfoMap{}
 }
 
-func (m *Manager) AddSubnetInfo(cidr *net.IPNet, gateway, start, end net.IP, excludeIPs, reservedIPs []net.IP,
+func (m *Manager) AddSubnetInfo(cidr *net.IPNet, gateway, start, end net.IP, excludeIPs []net.IP,
 	forwardNodeIfName string, autoNatOutgoing, isOverlay bool) {
 
 	cidrString := cidr.String()
@@ -185,15 +185,10 @@ func (m *Manager) AddSubnetInfo(cidr *net.IPNet, gateway, start, end net.IP, exc
 			autoNatOutgoing:   autoNatOutgoing,
 			includedIPRanges:  []*daemonutils.IPRange{},
 			excludeIPs:        []net.IP{},
-			reservedIPs:       []net.IP{},
 		}
 	}
 
 	subnetInfo := m.totalSubnetInfoMap[cidrString]
-
-	if len(reservedIPs) != 0 {
-		subnetInfo.reservedIPs = append(subnetInfo.reservedIPs, reservedIPs...)
-	}
 
 	if len(excludeIPs) != 0 {
 		subnetInfo.excludeIPs = append(subnetInfo.excludeIPs, excludeIPs...)

--- a/pkg/daemon/route/route.go
+++ b/pkg/daemon/route/route.go
@@ -290,7 +290,7 @@ func (m *Manager) SyncRoutes() error {
 		if err := ensureFromPodSubnetRuleAndRoutes(info.forwardNodeIfName, info.cidr,
 			info.gateway, info.autoNatOutgoing, true, m.family,
 			m.underlaySubnetInfoMap, underlayExcludeIPBlockMap); err != nil {
-			return fmt.Errorf("add subnet %v rule and routes failed: %v", info, err)
+			return fmt.Errorf("add subnet %v rule and routes failed: %v", info.cidr, err)
 		}
 	}
 
@@ -299,7 +299,7 @@ func (m *Manager) SyncRoutes() error {
 		if err := ensureFromPodSubnetRuleAndRoutes(info.forwardNodeIfName, info.cidr,
 			info.gateway, info.autoNatOutgoing, false, m.family,
 			nil, nil); err != nil {
-			return fmt.Errorf("add subnet %v rule and routes failed: %v", info, err)
+			return fmt.Errorf("add subnet %v rule and routes failed: %v", info.cidr, err)
 		}
 	}
 

--- a/pkg/daemon/route/utils.go
+++ b/pkg/daemon/route/utils.go
@@ -44,7 +44,6 @@ type SubnetInfo struct {
 	forwardNodeIfName string
 	autoNatOutgoing   bool
 	excludeIPs        []net.IP
-	reservedIPs       []net.IP
 	includedIPRanges  []*daemonutils.IPRange
 }
 
@@ -484,7 +483,7 @@ func findExcludeIPBlockMap(subnetInfoMap SubnetInfoMap) (map[string]*net.IPNet, 
 	excludeIPBlockMap := map[string]*net.IPNet{}
 	for _, info := range subnetInfoMap {
 		excludeIPBlocks, err := daemonutils.FindSubnetExcludeIPBlocks(info.cidr, info.includedIPRanges,
-			info.gateway, info.excludeIPs, info.reservedIPs)
+			info.gateway, info.excludeIPs)
 
 		if err != nil {
 			return nil, fmt.Errorf("find excluded ip blocks for subnet %v failed: %v", info.cidr, err)

--- a/pkg/daemon/server/container.go
+++ b/pkg/daemon/server/container.go
@@ -30,7 +30,7 @@ import (
 
 // ipAddr is a CIDR notation IP address and prefix length
 func (cdh cniDaemonHandler) configureNic(podName, podNamespace, netns, containerID, mac string,
-	vlanID *uint32, allocatedIPs map[ramav1.IPVersion]*containernetwork.IPInfo, networkType ramav1.NetworkType) (string, error) {
+	netID *uint32, allocatedIPs map[ramav1.IPVersion]*containernetwork.IPInfo, networkType ramav1.NetworkType) (string, error) {
 
 	var err error
 	var nodeIfName string
@@ -61,7 +61,7 @@ func (cdh cniDaemonHandler) configureNic(podName, podNamespace, netns, container
 
 	klog.Infof("Configure container nic for %v.%v", podName, podNamespace)
 	if err = containernetwork.ConfigureContainerNic(containerNicName, hostNicName, nodeIfName,
-		allocatedIPs, macAddr, vlanID, podNS, mtu, cdh.config.VlanCheckTimeout, networkType,
+		allocatedIPs, macAddr, netID, podNS, mtu, cdh.config.VlanCheckTimeout, networkType,
 		cdh.config.NeighGCThresh1, cdh.config.NeighGCThresh2, cdh.config.NeighGCThresh3); err != nil {
 		return "", fmt.Errorf("failed to configure container nic for %v.%v: %v", podName, podNamespace, err)
 	}

--- a/pkg/daemon/server/handle.go
+++ b/pkg/daemon/server/handle.go
@@ -90,12 +90,12 @@ func (cdh cniDaemonHandler) handleAdd(req *restful.Request, resp *restful.Respon
 
 	var returnIPAddress []request.IPAddress
 
-	backoffBase := 5 * time.Microsecond
+	backOffBase := 5 * time.Microsecond
 	retries := 11
 
 	for i := 0; i < retries; i++ {
-		time.Sleep(backoffBase)
-		backoffBase = backoffBase * 2
+		time.Sleep(backOffBase)
+		backOffBase = backOffBase * 2
 
 		pod, err := cdh.KubeClient.CoreV1().Pods(podRequest.PodNamespace).Get(context.TODO(), podRequest.PodName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/daemon/utils/ip_range.go
+++ b/pkg/daemon/utils/ip_range.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Rama Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (
@@ -33,19 +49,24 @@ func (ir *IPRange) TryAddIP(ipAddr net.IP) (success bool) {
 	if ipAddr.Equal(ip.PrevIP(ir.start)) {
 		ir.start = ipAddr
 		return true
-	} else if ipAddr.Equal(ip.NextIP(ir.end)) {
+	}
+
+	if ipAddr.Equal(ip.NextIP(ir.end)) {
 		ir.end = ipAddr
 		return true
-	} else if ip.Cmp(ipAddr, ir.start) >= 0 && ip.Cmp(ipAddr, ir.end) <= 0 {
+	}
+
+	if ip.Cmp(ipAddr, ir.start) >= 0 && ip.Cmp(ipAddr, ir.end) <= 0 {
 		// a range exist which includes this ip address
 		return true
 	}
+
 	return false
 }
 
 // Translate a subnet range into a series ip block description.
 func FindSubnetExcludeIPBlocks(cidr *net.IPNet, includedRanges []*IPRange, gateway net.IP,
-	excludeIPs, reservedIPs []net.IP) ([]*net.IPNet, error) {
+	excludeIPs []net.IP) ([]*net.IPNet, error) {
 
 	cidrStart := cidr.IP
 	cidrEnd := LastIP(cidr)
@@ -104,10 +125,6 @@ func FindSubnetExcludeIPBlocks(cidr *net.IPNet, includedRanges []*IPRange, gatew
 	}
 
 	allExcludedIPs := excludeIPs
-	if len(reservedIPs) != 0 {
-		allExcludedIPs = append(allExcludedIPs, reservedIPs...)
-	}
-
 	if gateway != nil {
 		allExcludedIPs = append(allExcludedIPs, gateway)
 	}

--- a/pkg/daemon/utils/ip_range.go
+++ b/pkg/daemon/utils/ip_range.go
@@ -1,0 +1,226 @@
+package utils
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+	"sort"
+
+	"github.com/containernetworking/plugins/pkg/ip"
+)
+
+type IPRange struct {
+	start net.IP
+	end   net.IP
+}
+
+func CreateIPRange(start, end net.IP) (*IPRange, error) {
+	if start == nil || end == nil {
+		return nil, fmt.Errorf("start and end should not be nil")
+	}
+
+	if ip.Cmp(start, end) > 0 {
+		return nil, nil
+	}
+
+	return &IPRange{
+		start: start,
+		end:   end,
+	}, nil
+}
+
+func (ir *IPRange) TryAddIP(ipAddr net.IP) (success bool) {
+	if ipAddr.Equal(ip.PrevIP(ir.start)) {
+		ir.start = ipAddr
+		return true
+	} else if ipAddr.Equal(ip.NextIP(ir.end)) {
+		ir.end = ipAddr
+		return true
+	} else if ip.Cmp(ipAddr, ir.start) >= 0 && ip.Cmp(ipAddr, ir.end) <= 0 {
+		// a range exist which includes this ip address
+		return true
+	}
+	return false
+}
+
+// Translate a subnet range into a series ip block description.
+func FindSubnetExcludeIPBlocks(cidr *net.IPNet, includedRanges []*IPRange, gateway net.IP,
+	excludeIPs, reservedIPs []net.IP) ([]*net.IPNet, error) {
+
+	cidrStart := cidr.IP
+	cidrEnd := LastIP(cidr)
+
+	var excludeIPRanges []*IPRange
+
+	sort.Slice(includedRanges, func(i, j int) bool {
+		return ip.Cmp(includedRanges[i].start, includedRanges[j].start) < 0
+	})
+
+	for currentIPRangeIndex, currentIPRange := range includedRanges {
+		if ip.Cmp(currentIPRange.start, cidrStart) < 0 || ip.Cmp(currentIPRange.end, cidrEnd) > 0 {
+			return nil, fmt.Errorf("ip range %v~%v is out of cidr %v",
+				currentIPRange.start, currentIPRange.end, cidr)
+		}
+
+		if currentIPRangeIndex < (len(includedRanges)-1) &&
+			ip.Cmp(currentIPRange.end, includedRanges[currentIPRangeIndex+1].start) >= 0 {
+			return nil, fmt.Errorf("ip range is overlapped for range %v~%v and %v~%v",
+				currentIPRange.start, currentIPRange.end,
+				includedRanges[currentIPRangeIndex+1].start, includedRanges[currentIPRangeIndex+1].end)
+		}
+
+		if currentIPRangeIndex == 0 {
+			// add [cidrStart, currentRangeStartPrev] to exclude ip ranges
+			currentRangeStartPrev := ip.PrevIP(currentIPRange.start)
+
+			ipRange, err := CreateIPRange(cidrStart, currentRangeStartPrev)
+			if err != nil {
+				return nil, fmt.Errorf("create ip range for %v~%v failed: %v", cidrStart, currentRangeStartPrev, err)
+			}
+
+			if ipRange != nil {
+				excludeIPRanges = append(excludeIPRanges, ipRange)
+			}
+		}
+
+		var nextRangeStartPrev net.IP
+		if currentIPRangeIndex == len(includedRanges)-1 {
+			nextRangeStartPrev = cidrEnd
+		} else {
+			nextRangeStartPrev = ip.PrevIP(includedRanges[currentIPRangeIndex+1].start)
+		}
+
+		// add [endNext, nextRangeStartPrev] to exclude ip ranges
+		endNext := ip.NextIP(currentIPRange.end)
+
+		ipRange, err := CreateIPRange(endNext, nextRangeStartPrev)
+		if err != nil {
+			return nil, fmt.Errorf("create ip range for %v~%v failed: %v", endNext, nextRangeStartPrev, err)
+		}
+
+		if ipRange != nil {
+			excludeIPRanges = append(excludeIPRanges, ipRange)
+		}
+	}
+
+	allExcludedIPs := excludeIPs
+	if len(reservedIPs) != 0 {
+		allExcludedIPs = append(allExcludedIPs, reservedIPs...)
+	}
+
+	if gateway != nil {
+		allExcludedIPs = append(allExcludedIPs, gateway)
+	}
+
+Loop2:
+	for _, ipAddr := range allExcludedIPs {
+		if len(excludeIPRanges) != 0 {
+			for _, ipRange := range excludeIPRanges {
+				if ipRange.TryAddIP(ipAddr) {
+					continue Loop2
+				}
+			}
+		}
+
+		singleIPRange, err := CreateIPRange(ipAddr, ipAddr)
+		if err != nil {
+			return nil, fmt.Errorf("create ip range for ip %v failed: %v", ipAddr, err)
+		}
+		excludeIPRanges = append(excludeIPRanges, singleIPRange)
+	}
+
+	var excludeIPBlocks []*net.IPNet
+	for _, ipRange := range excludeIPRanges {
+		excludeIPBlocks = append(excludeIPBlocks, ipRange.splitIPRangeToIPBlocks()...)
+	}
+
+	return excludeIPBlocks, nil
+}
+
+func (ir *IPRange) splitIPRangeToIPBlocks() []*net.IPNet {
+	rangeStart := ir.start
+	rangeEnd := ir.end
+	nextRangeStart := rangeStart
+
+	var ipBlocks []*net.IPNet
+
+	for nextRangeStart != nil {
+		var newBlock *net.IPNet
+		newBlock, nextRangeStart = findTheFirstLargestCidr(nextRangeStart, rangeEnd)
+		ipBlocks = append(ipBlocks, newBlock)
+	}
+
+	return ipBlocks
+}
+
+func calculateIPLastZeroBits(ip net.IP) int {
+	zeroBits := 0
+	for {
+		nextPossibleZeroBits := zeroBits + 1
+		ipInt := ipToInt(ip)
+		ipUint64 := ipInt.Uint64()
+
+		if ipUint64 == (ipUint64>>nextPossibleZeroBits)<<nextPossibleZeroBits {
+			zeroBits = nextPossibleZeroBits
+		} else {
+			break
+		}
+	}
+
+	return zeroBits
+}
+
+func findTheFirstLargestCidr(start, end net.IP) (*net.IPNet, net.IP) {
+	// The max possible cidr size for the start ip to represent.
+	zeroBits := calculateIPLastZeroBits(start)
+	var ipLen = net.IPv4len * 8
+	if start.To4() == nil {
+		ipLen = net.IPv6len * 8
+	}
+
+	minCidrPrefixLen := ipLen - zeroBits
+	maxValidCidrPrefixLen := minCidrPrefixLen
+
+	for {
+		tmpCidr := &net.IPNet{
+			IP:   start,
+			Mask: net.CIDRMask(maxValidCidrPrefixLen, ipLen),
+		}
+
+		tmpCidrEnd := LastIP(tmpCidr)
+
+		if tmpCidrEnd.Equal(end) {
+			return tmpCidr, nil
+		}
+
+		if tmpCidr.Contains(end) {
+			maxValidCidrPrefixLen++
+		} else {
+			return tmpCidr, ip.NextIP(tmpCidrEnd)
+		}
+	}
+}
+
+func ipToInt(ip net.IP) *big.Int {
+	if v := ip.To4(); v != nil {
+		return big.NewInt(0).SetBytes(v)
+	}
+	return big.NewInt(0).SetBytes(ip.To16())
+}
+
+func intToIP(i *big.Int) net.IP {
+	return i.Bytes()
+}
+
+func LastIP(cidr *net.IPNet) net.IP {
+	cidrPrefixLen, ipLen := cidr.Mask.Size()
+
+	if cidrPrefixLen == ipLen {
+		return cidr.IP
+	}
+
+	cidrEndIPInt := ipToInt(cidr.IP)
+	cidrEndIPInt.Add(cidrEndIPInt, big.NewInt(1<<(ipLen-cidrPrefixLen)-1))
+
+	return intToIP(cidrEndIPInt)
+}

--- a/pkg/daemon/utils/ip_range_test.go
+++ b/pkg/daemon/utils/ip_range_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Rama Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (
@@ -11,7 +27,6 @@ type TestSubnetSpec struct {
 	includedRanges []*IPRange
 	gateway        net.IP
 	excludeIPs     []net.IP
-	reservedIPs    []net.IP
 
 	expectIPBlocks []*net.IPNet
 }
@@ -184,8 +199,6 @@ func TestFindSubnetExcludeIPBlocks(t *testing.T) {
 				net.ParseIP("192.168.3.50"),
 				net.ParseIP("192.168.3.120"),
 				net.ParseIP("192.168.3.121"),
-			},
-			reservedIPs: []net.IP{
 				net.ParseIP("192.168.3.160"),
 				net.ParseIP("192.168.3.207"),
 				net.ParseIP("192.168.3.224"),
@@ -228,23 +241,6 @@ func TestFindSubnetExcludeIPBlocks(t *testing.T) {
 			excludeIPs: []net.IP{
 				net.ParseIP("192.168.3.100"),
 			},
-			reservedIPs: []net.IP{
-				net.ParseIP("192.168.3.100"),
-			},
-			expectIPBlocks: []*net.IPNet{
-				{
-					IP:   net.ParseIP("192.168.3.100"),
-					Mask: net.CIDRMask(32, 32),
-				},
-			},
-		}, {
-			cidr: &net.IPNet{
-				IP:   net.ParseIP("192.168.3.100"),
-				Mask: net.CIDRMask(32, 32),
-			},
-			reservedIPs: []net.IP{
-				net.ParseIP("192.168.3.100"),
-			},
 			expectIPBlocks: []*net.IPNet{
 				{
 					IP:   net.ParseIP("192.168.3.100"),
@@ -254,19 +250,19 @@ func TestFindSubnetExcludeIPBlocks(t *testing.T) {
 		},
 	}
 
-	for _, test := range testCases {
+	for index, test := range testCases {
 		ipBlocks, _ := FindSubnetExcludeIPBlocks(test.cidr, test.includedRanges,
-			test.gateway, test.excludeIPs, test.reservedIPs)
+			test.gateway, test.excludeIPs)
 
 		if !blockSliceEqual(ipBlocks, test.expectIPBlocks) {
-			t.Fatalf("failed to parse ip range %v, result ip blocks: %v", test.String(), ipBlocks)
+			t.Fatalf("failed to parse case %v ip range %v, result ip blocks: %v", index, test.String(), ipBlocks)
 		}
 	}
 }
 
 func (ts *TestSubnetSpec) String() string {
-	return fmt.Sprintf("cidr: %v, includedIPRanges: %v, gateway: %v, excludeIPs: %v, reservedIPs: %v",
-		ts.cidr.String(), ts.includedRanges, ts.gateway.String(), ts.excludeIPs, ts.reservedIPs)
+	return fmt.Sprintf("cidr: %v, includedIPRanges: %v, gateway: %v, excludeIPs: %v",
+		ts.cidr.String(), ts.includedRanges, ts.gateway.String(), ts.excludeIPs)
 }
 
 func blockSliceEqual(slice1, slice2 []*net.IPNet) bool {

--- a/pkg/daemon/utils/ip_range_test.go
+++ b/pkg/daemon/utils/ip_range_test.go
@@ -1,0 +1,292 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+type TestSubnetSpec struct {
+	cidr           *net.IPNet
+	includedRanges []*IPRange
+	gateway        net.IP
+	excludeIPs     []net.IP
+	reservedIPs    []net.IP
+
+	expectIPBlocks []*net.IPNet
+}
+
+func TestFindSubnetExcludeIPBlocks(t *testing.T) {
+	testCases := []TestSubnetSpec{
+		{
+			cidr: &net.IPNet{
+				IP:   net.ParseIP("192.168.3.0"),
+				Mask: net.CIDRMask(24, 32),
+			},
+			expectIPBlocks: nil,
+		}, {
+			cidr: &net.IPNet{
+				IP:   net.ParseIP("192.168.3.0"),
+				Mask: net.CIDRMask(24, 32),
+			},
+			gateway: net.ParseIP("192.168.3.1"),
+			expectIPBlocks: []*net.IPNet{
+				{
+					IP:   net.ParseIP("192.168.3.1"),
+					Mask: net.CIDRMask(32, 32),
+				},
+			},
+		}, {
+			cidr: &net.IPNet{
+				IP:   net.ParseIP("192.168.3.0"),
+				Mask: net.CIDRMask(24, 32),
+			},
+			gateway: net.ParseIP("192.168.3.1"),
+			includedRanges: []*IPRange{
+				{
+					start: net.ParseIP("192.168.3.100"),
+					end:   net.ParseIP("192.168.3.200"),
+				},
+			},
+			expectIPBlocks: []*net.IPNet{
+				{
+					IP:   net.ParseIP("192.168.3.0"),
+					Mask: net.CIDRMask(26, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.64"),
+					Mask: net.CIDRMask(27, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.96"),
+					Mask: net.CIDRMask(30, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.201"),
+					Mask: net.CIDRMask(32, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.202"),
+					Mask: net.CIDRMask(31, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.204"),
+					Mask: net.CIDRMask(30, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.208"),
+					Mask: net.CIDRMask(28, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.224"),
+					Mask: net.CIDRMask(27, 32),
+				},
+			},
+		}, {
+			cidr: &net.IPNet{
+				IP:   net.ParseIP("192.168.3.0"),
+				Mask: net.CIDRMask(24, 32),
+			},
+			gateway: net.ParseIP("192.168.3.1"),
+			includedRanges: []*IPRange{
+				{
+					start: net.ParseIP("192.168.3.100"),
+					end:   net.ParseIP("192.168.3.150"),
+				}, {
+					start: net.ParseIP("192.168.3.151"),
+					end:   net.ParseIP("192.168.3.200"),
+				},
+			},
+			expectIPBlocks: []*net.IPNet{
+				{
+					IP:   net.ParseIP("192.168.3.0"),
+					Mask: net.CIDRMask(26, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.64"),
+					Mask: net.CIDRMask(27, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.96"),
+					Mask: net.CIDRMask(30, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.201"),
+					Mask: net.CIDRMask(32, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.202"),
+					Mask: net.CIDRMask(31, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.204"),
+					Mask: net.CIDRMask(30, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.208"),
+					Mask: net.CIDRMask(28, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.224"),
+					Mask: net.CIDRMask(27, 32),
+				},
+			},
+		}, {
+			cidr: &net.IPNet{
+				IP:   net.ParseIP("192.168.3.0"),
+				Mask: net.CIDRMask(24, 32),
+			},
+			gateway: net.ParseIP("192.168.3.1"),
+			includedRanges: []*IPRange{
+				{
+					start: net.ParseIP("192.168.3.100"),
+					end:   net.ParseIP("192.168.3.150"),
+				}, {
+					start: net.ParseIP("192.168.3.152"),
+					end:   net.ParseIP("192.168.3.200"),
+				}, {
+					start: net.ParseIP("192.168.3.208"),
+					end:   net.ParseIP("192.168.3.223"),
+				},
+			},
+			expectIPBlocks: []*net.IPNet{
+				{
+					IP:   net.ParseIP("192.168.3.0"),
+					Mask: net.CIDRMask(26, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.64"),
+					Mask: net.CIDRMask(27, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.96"),
+					Mask: net.CIDRMask(30, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.201"),
+					Mask: net.CIDRMask(32, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.202"),
+					Mask: net.CIDRMask(31, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.204"),
+					Mask: net.CIDRMask(30, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.151"),
+					Mask: net.CIDRMask(32, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.224"),
+					Mask: net.CIDRMask(27, 32),
+				},
+			},
+		}, {
+			cidr: &net.IPNet{
+				IP:   net.ParseIP("192.168.3.0"),
+				Mask: net.CIDRMask(24, 32),
+			},
+			gateway: net.ParseIP("192.168.3.1"),
+			includedRanges: []*IPRange{
+				{
+					start: net.ParseIP("192.168.3.100"),
+					end:   net.ParseIP("192.168.3.150"),
+				}, {
+					start: net.ParseIP("192.168.3.151"),
+					end:   net.ParseIP("192.168.3.200"),
+				}, {
+					start: net.ParseIP("192.168.3.208"),
+					end:   net.ParseIP("192.168.3.223"),
+				},
+			},
+			excludeIPs: []net.IP{
+				net.ParseIP("192.168.3.50"),
+				net.ParseIP("192.168.3.120"),
+				net.ParseIP("192.168.3.121"),
+			},
+			reservedIPs: []net.IP{
+				net.ParseIP("192.168.3.160"),
+				net.ParseIP("192.168.3.207"),
+				net.ParseIP("192.168.3.224"),
+			},
+			expectIPBlocks: []*net.IPNet{
+				{
+					IP:   net.ParseIP("192.168.3.0"),
+					Mask: net.CIDRMask(26, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.64"),
+					Mask: net.CIDRMask(27, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.96"),
+					Mask: net.CIDRMask(30, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.120"),
+					Mask: net.CIDRMask(31, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.160"),
+					Mask: net.CIDRMask(32, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.201"),
+					Mask: net.CIDRMask(32, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.202"),
+					Mask: net.CIDRMask(31, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.204"),
+					Mask: net.CIDRMask(30, 32),
+				}, {
+					IP:   net.ParseIP("192.168.3.224"),
+					Mask: net.CIDRMask(27, 32),
+				},
+			},
+		}, {
+			cidr: &net.IPNet{
+				IP:   net.ParseIP("192.168.3.100"),
+				Mask: net.CIDRMask(32, 32),
+			},
+			excludeIPs: []net.IP{
+				net.ParseIP("192.168.3.100"),
+			},
+			reservedIPs: []net.IP{
+				net.ParseIP("192.168.3.100"),
+			},
+			expectIPBlocks: []*net.IPNet{
+				{
+					IP:   net.ParseIP("192.168.3.100"),
+					Mask: net.CIDRMask(32, 32),
+				},
+			},
+		}, {
+			cidr: &net.IPNet{
+				IP:   net.ParseIP("192.168.3.100"),
+				Mask: net.CIDRMask(32, 32),
+			},
+			reservedIPs: []net.IP{
+				net.ParseIP("192.168.3.100"),
+			},
+			expectIPBlocks: []*net.IPNet{
+				{
+					IP:   net.ParseIP("192.168.3.100"),
+					Mask: net.CIDRMask(32, 32),
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		ipBlocks, _ := FindSubnetExcludeIPBlocks(test.cidr, test.includedRanges,
+			test.gateway, test.excludeIPs, test.reservedIPs)
+
+		if !blockSliceEqual(ipBlocks, test.expectIPBlocks) {
+			t.Fatalf("failed to parse ip range %v, result ip blocks: %v", test.String(), ipBlocks)
+		}
+	}
+}
+
+func (ts *TestSubnetSpec) String() string {
+	return fmt.Sprintf("cidr: %v, includedIPRanges: %v, gateway: %v, excludeIPs: %v, reservedIPs: %v",
+		ts.cidr.String(), ts.includedRanges, ts.gateway.String(), ts.excludeIPs, ts.reservedIPs)
+}
+
+func blockSliceEqual(slice1, slice2 []*net.IPNet) bool {
+	if len(slice1) != len(slice2) {
+		return false
+	}
+
+	for _, block := range slice1 {
+		found := false
+		for _, targetBlock := range slice2 {
+			if targetBlock.String() == block.String() {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/oecp/rama/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Rama support a flexible ip range configuration, in which even a discontinuous ip address range can be described. While if a subnet CIDR has some excluded ip addresses, there would be some problem for overlay pod to access these excluded ip addresses.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #30 

### Describe how you did it
Four cases should be considered:

1. Underlay pod to access underlay excluded ip addresses: the same with underlay pod' accessing other underlay addresses, not changed.
2. Underlay pod to access overlay excluded ip addresses: this traffic should never pass through vxlan interface.
3. Overlay pod to access overlay excluded ip addresses: the same with overlay pod's accessing ip addresses outside the cluster, should never pass through vxlan interface.
4. Overlay pod to access underlay excluded ip addresses: the same with overlay pod's accessing ip addresses outside the cluster, should never pass through vxlan interface.

So, in the PR, I add some `throw` routes to handle the traffic with excluded destination address blocks, to make traffic don't pass through the vxlan interface if either it's destination is a overlay excluded ip addresses or it's the traffic from overlay pod to underlay excluded ip addresses.

### Describe how to verify it
Use overlay pod to access underlay gateway or excluded ip addresses.

### Special notes for reviews