### PR TITLE
improvement: clear-stale-neigh-entries-for-overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed Issues
 - Fix error data path for overlay pod to access underlay gateway and excluded ip addresses
+
+## v0.1.2
+### Improvements
+- Clear stale neigh entries for overlay network

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Rama
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/oecp/rama)](https://goreportcard.com/report/github.com/oecp/rama)
+[![Github All Releases](https://img.shields.io/docker/pulls/ramanetworking/rama.svg)](https://hub.docker.com/r/ramanetworking/rama/tags)
+[![codecov](https://codecov.io/gh/oecp/rama/branch/main/graphs/badge.svg)](https://codecov.io/gh/oecp/rama)
+
 ## What is Rama?
 
 Rama is an open source container networking solution, integrated with Kubernetes and used officially by following well-known PaaS platforms,

--- a/pkg/daemon/neigh/utils.go
+++ b/pkg/daemon/neigh/utils.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2021 The Rama Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neigh
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+// If neigh entry not exist, return nil
+func ClearStaleNeighEntryByIP(linkIndex int, ip net.IP) error {
+	family := netlink.FAMILY_V4
+	if ip.To4() == nil {
+		family = netlink.FAMILY_V6
+	}
+
+	neighList, err := netlink.NeighList(linkIndex, family)
+	if err != nil {
+		return fmt.Errorf("list neigh for link index %v error: %v", linkIndex, err)
+	}
+
+	for _, neigh := range neighList {
+		if neigh.IP.Equal(ip) && neigh.State == netlink.NUD_STALE {
+			if err := netlink.NeighDel(&neigh); err != nil {
+				return fmt.Errorf("del neigh cache %v error: %v", neigh.String(), err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func ClearStaleNeighEntries(linkIndex int) error {
+	for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
+		neighList, err := netlink.NeighList(linkIndex, family)
+		if err != nil {
+			return fmt.Errorf("list neigh for link index %v error: %v", linkIndex, err)
+		}
+
+		for _, neigh := range neighList {
+			if neigh.State == netlink.NUD_STALE {
+				if err := netlink.NeighDel(&neigh); err != nil {
+					return fmt.Errorf("del neigh cache %v error: %v", neigh.String(), err)
+				}
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/oecp/rama/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Consume there is a node A (it's the same thing for pod on this node) has accessed pod B, there will be a REACHABLE neigh entry for pod B on node A. If the pod B is deleted, and after a period of time, neigh entry for pod B on node A will become STALE, even pod B has been recreate on another different node, this neigh entry will not be updated, because there is no gratuitous arp/ndp for overlay network.

This is because kernel will never clear a STALE neigh entry if the number of all neigh entries on this node is under the limit of gc_thresh parameter, which will cause a problem of seconds packet loss while this node want to rebuild a connection to the new pod B.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
Clear STALE neigh entries for vxlan interface once the rama-daemon pod is running, and clear specific STALE neigh if the ip is not found by neigh proxy.

### Describe how to verify it
1. recreate rama-daemon pod to clear STALE neigh entries.
2. delete an exist pod and check if the STALE neigh cache will be cleaned for all nodes.

### Special notes for reviews